### PR TITLE
Issue-1 Only set the sublocation when the string not empty

### DIFF
--- a/src/StageDischargeReadingsPlugin/Parsers/StageDischargeRecord.cs
+++ b/src/StageDischargeReadingsPlugin/Parsers/StageDischargeRecord.cs
@@ -130,7 +130,7 @@ namespace StageDischargeReadingsPlugin.Parsers
                     DateTimeOffset = readingTime,
                     ReadingType = ReadingType ?? FieldDataPluginFramework.DataModel.Readings.ReadingType.Unknown,
                     Uncertainty = ReadingUncertainty,
-                    SubLocation = ReadingSublocation
+                    SubLocation = string.IsNullOrEmpty(ReadingSublocation) ? null : ReadingSublocation
                 };
 
                 if (!string.IsNullOrEmpty(ReadingMethod))


### PR DESCRIPTION
An empty string value will throw an exception during import.